### PR TITLE
Instance Datablocks declarations are now read from the Function Block

### DIFF
--- a/LibNoDaveConnectionLibrary/Communication/PLCConnectionConfiguration.cs
+++ b/LibNoDaveConnectionLibrary/Communication/PLCConnectionConfiguration.cs
@@ -862,6 +862,10 @@ namespace DotNetSiemensPLCToolBoxLibrary.Communication
         MPI_über_Serial_Adapter_Step_7_Version = 3,
         [XmlEnum("4")]
         MPI_über_Serial_Adapter_Adrews_Version_with_STX = 4,
+
+        /// <summary>
+        /// Connection via PPI protocoll of an MPI/PB adapter. This is usually used for S7-200 family
+        /// </summary>
         [XmlEnum("10")]
         PPI_über_Serial_Adapter = 10,
 
@@ -903,21 +907,52 @@ namespace DotNetSiemensPLCToolBoxLibrary.Communication
         // ReSharper restore InconsistentNaming
     }
 
+    /// <summary>
+    /// Communication Speeds for Profibus and MPI bus connection Adapters.
+    /// The possible speeds can not be chosen freely, but are rather defined by the ProfiBus Standard
+    /// </summary>
     public enum LibNodaveConnectionBusSpeed
     {
         // ReSharper disable InconsistentNaming
+        /// <summary>
+        /// 9.6 kbps
+        /// </summary>
         [XmlEnum("0")]
         Speed_9k = 0,
+
+        /// <summary>
+        /// 19.2 kbps
+        /// </summary>
         [XmlEnum("1")]
         Speed_19k = 1,
+
+        /// <summary>
+        /// 187,5 kbps
+        /// </summary>
         [XmlEnum("2")]
         Speed_187k = 2,
+
+        /// <summary>
+        /// 0,5 Mbps
+        /// </summary>
         [XmlEnum("3")]
         Speed_500k = 3,
+
+        /// <summary>
+        /// 1.5 Mbps
+        /// </summary>
         [XmlEnum("4")]
         Speed_1500k = 4,
+
+        /// <summary>
+        /// 45.45 kbps
+        /// </summary>
         [XmlEnum("5")]
         Speed_45k = 5,
+
+        /// <summary>
+        /// 93.75 kbps
+        /// </summary>
         [XmlEnum("6")]
         Speed_93k = 6
         // ReSharper restore InconsistentNaming

--- a/LibNoDaveConnectionLibrary/DataTypes/AWL/Step7V5/S7ConvertingOptions.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/AWL/Step7V5/S7ConvertingOptions.cs
@@ -2,11 +2,22 @@
 
 namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.AWL.Step7V5
 {
+    /// <summary>
+    /// Options that define how Step7 Project will behave when opened by this library. 
+    /// </summary>
     public class S7ConvertingOptions
     {
         protected bool Equals(S7ConvertingOptions other)
         {
-            return this.UseComments.Equals(other.UseComments) && this.Mnemonic == other.Mnemonic && this.CombineDBOpenAndDBAccess.Equals(other.CombineDBOpenAndDBAccess) && this.ReplaceDBAccessesWithSymbolNames.Equals(other.ReplaceDBAccessesWithSymbolNames) && this.ReplaceLokalDataAddressesWithSymbolNames.Equals(other.ReplaceLokalDataAddressesWithSymbolNames) && this.ReplaceDIAccessesWithSymbolNames.Equals(other.ReplaceDIAccessesWithSymbolNames) && this.GenerateCallsfromUCs.Equals(other.GenerateCallsfromUCs) && this.UseInFCStoredFCsForCalls.Equals(other.UseInFCStoredFCsForCalls);
+            return this.UseComments.Equals(other.UseComments) 
+                && this.Mnemonic == other.Mnemonic 
+                && this.CombineDBOpenAndDBAccess.Equals(other.CombineDBOpenAndDBAccess) 
+                && this.ReplaceDBAccessesWithSymbolNames.Equals(other.ReplaceDBAccessesWithSymbolNames) 
+                && this.ReplaceLokalDataAddressesWithSymbolNames.Equals(other.ReplaceLokalDataAddressesWithSymbolNames) 
+                && this.ReplaceDIAccessesWithSymbolNames.Equals(other.ReplaceDIAccessesWithSymbolNames) 
+                && this.GenerateCallsfromUCs.Equals(other.GenerateCallsfromUCs) 
+                && this.UseInFCStoredFCsForCalls.Equals(other.UseInFCStoredFCsForCalls)
+                && this.UseFBDeclarationForInstanceDB.Equals(other.UseFBDeclarationForInstanceDB);
         }
 
         public override int GetHashCode()
@@ -21,6 +32,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.AWL.Step7V5
                 hashCode = (hashCode * 397) ^ this.ReplaceDIAccessesWithSymbolNames.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.GenerateCallsfromUCs.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.UseInFCStoredFCsForCalls.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.UseFBDeclarationForInstanceDB.GetHashCode();
                 return hashCode;
             }
         }
@@ -40,6 +52,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.AWL.Step7V5
             this.GenerateCallsfromUCs = true;
             this.UseInFCStoredFCsForCalls = true; //todo implement the reading of them in the step7 project
             this.UseComments = true;
+            this.UseFBDeclarationForInstanceDB = true; //Default to Simatic Mamager Behavior
         }
 
         public bool UseComments { get; set; }
@@ -53,6 +66,13 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.AWL.Step7V5
 
         public bool GenerateCallsfromUCs { get; set;}
         public bool UseInFCStoredFCsForCalls { get; set; }
+
+        /// <summary>
+        /// use the FB instance declartion symbolics for displaying Instance DB Variables
+        /// Otherwise it is using the Symbolics stored for each individual instance DB, which may be different than the Function Block
+        /// The Step7 Default is TRUE. Simatic Manager always shows the FB declarations.
+        /// </summary>
+        public bool UseFBDeclarationForInstanceDB { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
@@ -64,6 +64,10 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
             get { return readPlcBlocksList(); }
         }
 
+        /// <summary>
+        /// Read all blocks from the S7 Project and cache them into the 'tmpBlocks' field.
+        /// </summary>
+        /// <returns></returns>
         private List<ProjectBlockInfo> intReadPlcBlocksList()
         {
             bool showDeleted = ((Step7ProjectV5)this.Project)._showDeleted;
@@ -122,6 +126,9 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
             return tmpBlocks;
         }
 
+        /// <summary>
+        /// Help class, used to hold unparsed raw data read from the S7 Project files from disk
+        /// </summary>
         private class tmpBlock
         {
             public byte[] mc7code;
@@ -143,7 +150,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
             public int FBNumber;
         }
 
-        private Dictionary<string, tmpBlock> tmpBlocks;
+        private Dictionary<string, tmpBlock> tmpBlocks; //internal cached list of blocks already read from the S7 Project
 
         public ProjectBlockInfo GetProjectBlockInfoFromBlockName(string BlockName)
         {
@@ -153,22 +160,6 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                 if (step7ProjectBlockInfo.BlockType.ToString() + step7ProjectBlockInfo.BlockNumber.ToString() == BlockName.ToUpper())
                     return step7ProjectBlockInfo;
             }
-            return null;
-        }
-
-        public Block GetBlock(string BlockName)
-        {
-            var prjBlkInf = GetProjectBlockInfoFromBlockName(BlockName);
-            if (prjBlkInf != null)
-                return GetBlock(prjBlkInf);
-            return null;
-        }
-
-        public Block GetBlock(string BlockName, S7ConvertingOptions myConvOpt)
-        {
-            var prjBlkInf = GetProjectBlockInfoFromBlockName(BlockName);
-            if (prjBlkInf != null)
-                return GetBlock(prjBlkInf, myConvOpt);
             return null;
         }
 
@@ -240,6 +231,11 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
             }
         }
 
+        /// <summary>
+        /// Reads the raw data from the S7 Project files, without parsing the data
+        /// </summary>
+        /// <param name="blkInfo">The Block info object that identifies the block to read from Disk</param>
+        /// <returns></returns>
         private tmpBlock GetBlockBytes(ProjectBlockInfo blkInfo)
         {
             if (subblkDBF != null) //ZipHelper.FileExists(((Step7ProjectV5)Project)._zipfile, Folder + "SUBBLK.DBF"))
@@ -323,8 +319,9 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                         {
                             //DB Structure in Plain Text (Structure and StartValues!)
                             if (mc5code != null)
-                                myTmpBlk.blkinterface =
-                                    Project.ProjectEncoding.GetString(mc5code);
+                                if (!myTmpBlk.IsInstanceDB ) //only take interface if the block is not an instance DB. If it is, then reather take the interface from the FB declaration
+                                    myTmpBlk.blkinterface =
+                                        Project.ProjectEncoding.GetString(mc5code);
                             //Maybe compiled DB Structure?
                             myTmpBlk.addinfo = addinfo;
                         }
@@ -343,6 +340,14 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                                 // I do not know what value for SFB
                                 myTmpBlk.IsInstanceDB = true;
                                 myTmpBlk.FBNumber = (int)ssbpart[1] + 256 * (int)ssbpart[2];
+
+                                //if this is an interface DB, then rather take the Interface declaration from the instance FB,
+                                //instead of the data sotred in the project. 
+                                //The reason is that if you change the comment in an FB, the DB data is not actualized and my contain outdated
+                                //Declarations. When you change the interface, Step7 tells you to "regenerate" the instance DB which only then would 
+                                //Actualize the comments. Simple Commentary changes do not change the Datablocks row. 
+                                tmpBlock InstFB = GetBlockBytes("FB" + myTmpBlk.FBNumber);
+                                myTmpBlk.blkinterface = InstFB.blkinterface;
                             }
                         }
                         else if (subblktype == 0x14) //DB
@@ -375,6 +380,19 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
             return null;
         }
 
+        /// <summary>
+        /// Reads the raw data from the S7 Project files, without parsing the data
+        /// </summary>
+        /// <param name="blkName">The blockname to be read from disk. eg. DB2, FB38....</param>
+        /// <returns></returns>
+        private tmpBlock GetBlockBytes(string blkName)
+        {
+            var blkInfo = GetProjectBlockInfoFromBlockName(blkName);
+            if (blkInfo == null)
+                return null;
+           return GetBlockBytes(blkInfo);
+        }
+
         public S7DataRow GetInterface(string blkName)
         {
             var blkInfo = GetProjectBlockInfoFromBlockName(blkName);
@@ -385,11 +403,49 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
             return Parameter.GetInterfaceOrDBFromStep7ProjectString(myTmpBlk.blkinterface, ref tmpPar, blkInfo.BlockType, false, this, null);
         }
 
+        /// <summary>
+        /// Reads an Block from the Project and returns the block data that is stored in the S7 Project
+        /// </summary>
+        /// <param name="BlockName">The blockname to be read from disk. eg. DB2, FB38....</param>
+        /// <returns></returns>
+        public Block GetBlock(string BlockName)
+        {
+            var prjBlkInf = GetProjectBlockInfoFromBlockName(BlockName);
+            if (prjBlkInf != null)
+                return GetBlock(prjBlkInf);
+            return null;
+        }
+
+        /// <summary>
+        /// Reads an Block from the Project and returns the block data that is stored in the S7 Project
+        /// </summary>
+        /// <param name="BlockName">The blockname to be read from disk. eg. DB2, FB38....</param>
+        /// <param name="myConvOpt">Defines options that determine how the Block will be converted</param>
+        /// <returns></returns>
+        public Block GetBlock(string BlockName, S7ConvertingOptions myConvOpt)
+        {
+            var prjBlkInf = GetProjectBlockInfoFromBlockName(BlockName);
+            if (prjBlkInf != null)
+                return GetBlock(prjBlkInf, myConvOpt);
+            return null;
+        }
+
+        /// <summary>
+        /// Reads an Block from the Project and returns the block data that is stored in the S7 Project
+        /// </summary>
+        /// <param name="blkInfo">The Block info object that identifies the block to read from Disk</param>
+        /// <returns></returns>
         public Block GetBlock(ProjectBlockInfo blkInfo)
         {
             return GetBlock(blkInfo, new S7ConvertingOptions(Project.ProjectLanguage) { GenerateCallsfromUCs = false });
         }
 
+        /// <summary>
+        /// Reads an Block from the Project and returns the block data that is stored in the S7 Project
+        /// </summary>
+        /// <param name="blkInfo">The Block info object that identifies the block to read from Disk</param>
+        /// <param name="myConvOpt">Defines options that determine how the Block will be converted</param>
+        /// <returns></returns>
         public Block GetBlock(ProjectBlockInfo blkInfo, S7ConvertingOptions myConvOpt)
         {
             if (blkInfo._Block != null && ((blkInfo._Block) as S7Block).usedS7ConvertingOptions.Equals(myConvOpt)) 
@@ -688,10 +744,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                 }
             }
             return null;
-        }
-
-
-       
+        }     
 
         /// <summary>
         /// With this Function you get the AWL Source of a Block, so that it can be imported into Step7


### PR DESCRIPTION
This is to make the behavior consistent with Step7. 
Also reorders the class a little bit and added comments. 

The behavior is fixed, and not yet adjustable via options. The important change is all in "private tmpBlock GetBlockBytes(ProjectBlockInfo blkInfo)"
