### PR TITLE
Bug Fix in Parsing of FB and Datablocks and Proper S7Attribute Parsing

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
@@ -37,9 +37,9 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
     {
         internal S7ConvertingOptions usedS7ConvertingOptions;
 
-        public string BlockVersion;
+        public Version BlockVersion;
 
-        public String BlockAttribute; // .0 not unlinked, .1 standart block + know how protect, .3 know how protect, .5 not retain
+        public S7BlockAtributes BlockAttribute; // .0 not unlinked, .1 standart block + know how protect, .3 know how protect, .5 not retain
 
         public List<Step7Attribute> Attributes { get; set; }
 
@@ -102,6 +102,39 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
                 }
                 return null;
             }
+        }
+
+        [Flags]
+        public enum S7BlockAtributes: byte
+        {
+            /// <summary>
+            /// The block exists in the controller, and is also linked into execution
+            /// For Code blocks such as FB or FC, this means that they are existing in the controller but not actually executed
+            /// For data blocks this means, that they do not have any Actual values assigned to them. Any attempt to read current data from them will fail.
+            /// </summary>
+            Linked = 1, //.0
+
+            /// <summary>
+            /// This is an standard block from the default library
+            /// </summary>
+            StandardBlock = 2, //.1
+
+            /// <summary>
+            /// The block is protected by an Password
+            /// </summary>
+            KnowHowProtected = 8, //.3
+
+            /// <summary>
+            /// Only applies to datablocks. if an DB is non retentive, its actual data get reset to its initial values every time the controller
+            /// restarts
+            /// </summary>
+            NonRetain = 32 //.5
+
+            //These two Attributes somehow do not appear on online blocks, even though they are settabele in Simatic Manager
+            //Maybe some more testing is necesary
+            //WriteProtected
+            //ReadOnly
+
         }
     }
 }

--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
@@ -108,10 +108,16 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
         public enum S7BlockAtributes: byte
         {
             /// <summary>
-            /// The block exists in the controller, and is also linked into execution
-            /// For Code blocks such as FB or FC, this means that they are existing in the controller but not actually executed
-            /// For data blocks this means, that they do not have any Actual values assigned to them. Any attempt to read current data from them will fail.
+            /// The block exists in the controller, and is also linked into execution.
+            /// if this attribute is FALSE:
+            /// -For Code blocks such as FB or FC, this means that they are existing in the controller but not actually executed
+            /// -For data blocks this means, that they do not have any Actual values assigned to them. Any attempt to read current data from them will fail.
             /// </summary>
+            /// <remarks>
+            /// This corresponds to the "Unlinked" attribute in the Simatic manager, which actually shows the status in reverse
+            /// This Attribute is only false when either especifically selected from simatic manager (only possible for Datablocks)
+            /// or during a breif period when an Code block is alrady downloaded, but not yet linked (usually part of the "Block Download" process
+            /// </remarks>
             Linked = 1, //.0
 
             /// <summary>

--- a/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/MC7Converter.cs
+++ b/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/MC7Converter.cs
@@ -99,8 +99,8 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
                  * xx      = Nertworks
                  */
 
-                retBlock.BlockVersion = Convert.ToString(MC7Code[2] - 1);
-                retBlock.BlockAttribute = Convert.ToString(MC7Code[3] - 1);
+                retBlock.BlockVersion = new Version (MC7Code[2] /10, MC7Code[2] % 10); 
+                retBlock.BlockAttribute = (S7Block.S7BlockAtributes)MC7Code[3];
                 retBlock.BlockLanguage = (DataTypes.PLCLanguage)MC7Code[4]; // Enum.Parse(typeof(DataTypes.PLCLanguage), Helper.GetLang(MC7Code[4]));
                 retBlock.MnemonicLanguage = (MnemonicLanguage)MnemoricLanguage;
                 retBlock.BlockType = Helper.GetPLCBlockType(MC7Code[5]);
@@ -189,8 +189,8 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
                  * xx      = Nertworks
                  */
 
-                retBlock.BlockVersion = Convert.ToString(MC7Code[2] - 1);
-                retBlock.BlockAttribute = Convert.ToString(MC7Code[3] - 1);
+                retBlock.BlockVersion = new Version(MC7Code[2] / 10, MC7Code[2] % 10);
+                retBlock.BlockAttribute = (S7Block.S7BlockAtributes)MC7Code[3];
                 retBlock.BlockLanguage = (DataTypes.PLCLanguage)MC7Code[4]; // Enum.Parse(typeof(DataTypes.PLCLanguage), Helper.GetLang(MC7Code[4]));
                 retBlock.MnemonicLanguage = (MnemonicLanguage)MnemoricLanguage;
                 retBlock.BlockType = Helper.GetPLCBlockType(MC7Code[5]);

--- a/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Parameter.cs
+++ b/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Parameter.cs
@@ -630,7 +630,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
             while (pos <= (interfaceBytes.Length-2)) // && pos < BD.Length - 2)  //pos<BD.Length-2 was added so SDBs can be converted!! but is this needed?
             {
                 object startVal;
-                if (Helper.IsWithStartVal(interfaceBytes[pos + 1]))
+                if (Helper.IsWithStartVal(interfaceBytes[pos + 1]) && actualvalueBytes != null)
                 {
                     if (interfaceBytes[pos] != 0x10) //Datentyp == Array...
                         startVal = GetVarTypeVal(interfaceBytes[pos], actualvalueBytes, ref Valpos);


### PR DESCRIPTION
Bug fix when parsing the FB or DB Interface, the the Actual values where not available

Added BlockAttributes and BlockVersion to the S7Block.

I encountered an problem when parsing the Block Version. With my testing data, the blocks have always been Version 1 (0.1) even though they should have had a different version. This was al ready like this in the raw MC7 code on Byte 2. So either the BLock version is stored at an different offset, or something else is going wrong.