### PR TITLE
Bug fix in the GetSZL function

### DIFF
--- a/LibNoDaveConnectionLibrary/Communication/PLCConnection.cs
+++ b/LibNoDaveConnectionLibrary/Communication/PLCConnection.cs
@@ -1524,7 +1524,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.Communication
         /// <param name="SZLNummer">The System State list Number</param>
         /// <param name="Index">The System State sub list number</param>
         /// <returns></returns>
-        public SZLData PLCGetSZL(Int16 SZLNummer, Int16 Index)
+        public SZLData PLCGetSZL(Int16 SZLNummer, UInt16 Index)
         {
             lock (lockObj)
             {

--- a/LibNoDaveConnectionLibrary/Communication/PLCConnection.cs
+++ b/LibNoDaveConnectionLibrary/Communication/PLCConnection.cs
@@ -1524,7 +1524,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.Communication
         /// <param name="SZLNummer">The System State list Number</param>
         /// <param name="Index">The System State sub list number</param>
         /// <returns></returns>
-        public SZLData PLCGetSZL(Int16 SZLNummer, UInt16 Index)
+        public SZLData PLCGetSZL(UInt16 SZLNummer, UInt16 Index)
         {
             lock (lockObj)
             {
@@ -1684,6 +1684,18 @@ namespace DotNetSiemensPLCToolBoxLibrary.Communication
                 }
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Upload an System State list (SZL) from the controller that hold configuration, state and capability information
+        /// For information about SZLNummbers and indexes please consult the information from SIEMENS regarding SFC51 "RDSYSST"
+        /// </summary>
+        /// <param name="SZLNummer">The System State list Number</param>
+        /// <param name="Index">The System State sub list number</param>
+        /// <returns></returns>
+        public SZLData PLCGetSZL(Int16 SZLNummer, Int16 Index)
+        {
+            return PLCGetSZL((UInt16)SZLNummer, (UInt16)Index);
         }
 
         /// <summary>

--- a/WPFToolboxForPLCs/DockableWindows/ContentWindowSZL.xaml.cs
+++ b/WPFToolboxForPLCs/DockableWindows/ContentWindowSZL.xaml.cs
@@ -31,7 +31,7 @@ namespace WPFToolboxForSiemensPLCs.DockableWindows
             App.clientForm.lblStatus.Text = "";
             try
             {
-                SZLData szlData = App.clientForm.Connection.PLCGetSZL((short) szlid, (short) szlindex);
+                SZLData szlData = App.clientForm.Connection.PLCGetSZL((short) szlid, (ushort) szlindex);
 
                 myDataGrid.Columns.Clear();
 

--- a/WPFToolboxForPLCs/DockableWindows/ContentWindowSZL.xaml.cs
+++ b/WPFToolboxForPLCs/DockableWindows/ContentWindowSZL.xaml.cs
@@ -31,7 +31,7 @@ namespace WPFToolboxForSiemensPLCs.DockableWindows
             App.clientForm.lblStatus.Text = "";
             try
             {
-                SZLData szlData = App.clientForm.Connection.PLCGetSZL((short) szlid, (ushort) szlindex);
+                SZLData szlData = App.clientForm.Connection.PLCGetSZL((ushort) szlid, (ushort) szlindex);
 
                 myDataGrid.Columns.Clear();
 


### PR DESCRIPTION
This is a Bug fix in the GetSZL function. The INDEX data-type is really an Uint16 and not an Int16.
The int16 definition lead to the following problem:

Some SZL's have their most significant bit set to TRUE. this happens in particular for SZL 0x0D91 (Uploading Module Information of an Profinet/DP device), when the station is on an Profinet System. In that case the INDEX parameter is something like "0x8006" or similar. The important thing is that the bit 15 is true (it indicates that we area dealing with an Profinet and not Profibus).
However the "readSZL" in the IDaveConnection interface defines an integer (32/64 bits). Unfortunately when you call into IDaveConnection.ReadSZL, the INDEX gets sign-expanded from an int16 to an int32/int64. But that is not correct. The Index parameter must not be expanded.

In the end this results that LibNoDave sends Index 0x8106 instead 0x8006 on the wire. I confirmed this with Wireshark, and the change from int16 to Uint16 fixes this issue.

This was tested on an VIPA 017 SLIO CPU (basically it is an S7-317 PN/DP in a smaller form factor), with an real Profinet Configuration.