### PR TITLE
Remove restriction of S7-1500 devices in TIA 15.1 module

### DIFF
--- a/DotNetSiemensPLCToolBoxLibrary.TIAV15_1/Step7ProjectV15_1Tia.cs
+++ b/DotNetSiemensPLCToolBoxLibrary.TIAV15_1/Step7ProjectV15_1Tia.cs
@@ -858,7 +858,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.Projectfiles.V15_1
 
             foreach (var d in tiapProject.Devices)
             {
-                if (d.TypeIdentifier != null && d.TypeIdentifier.EndsWith(".S71500"))
+                if (d.TypeIdentifier != null)
                 {
                     foreach (DeviceItem deviceItem in d.DeviceItems)
                     {


### PR DESCRIPTION
In reference to issue #149.

I have omitted the device series check within the TIA 15.1 module, my project works as expected with this check removed.
 
I did not update the others as I have not tested them.