### PR TITLE
Update AWLtoMC7.cs

### DIFF
--- a/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/AWLtoMC7.cs
+++ b/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/AWLtoMC7.cs
@@ -41,7 +41,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
             foreach (var myLine in ((S7FunctionBlock)myCmd).AWLCode)
             {
                 if (((S7FunctionBlockRow)myLine).MC7 == null) 
-                    ((S7FunctionBlockRow)myLine).MC7 = GetMC7(((S7FunctionBlockRow)myLine));
+                    ((S7FunctionBlockRow)myLine).MC7 = GetMC7(((S7FunctionBlockRow)myLine)) ?? new byte[0x00];
                 retVal.AddRange(((S7FunctionBlockRow)myLine).MC7);
             }
             return retVal.ToArray();


### PR DESCRIPTION
GetMC7() could return null which causes an ArgumentNullException when passed to AddRange()

This is the simplest way, with the least impact, to prevent the error