### PR TITLE
fix s7 sfb call parsing & index out of range errors

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
@@ -688,7 +688,11 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                                                     if (!newAwlCode.Contains(akRw))
                                                         newAwlCode.Add(akRw);
                                                 }
-                                                akRowInAwlCode++;
+
+                                                if (akRowInAwlCode < retVal.AWLCode.Count - 1)
+                                                {
+                                                    akRowInAwlCode++;
+                                                }
                                             }
                                             ((S7FunctionBlockRow)retVal.AWLCode[akRowInAwlCode]).NetworkName = tx1;
                                             ((S7FunctionBlockRow)retVal.AWLCode[akRowInAwlCode]).Comment = tx2;
@@ -713,7 +717,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                                                      akRw.CombineDBAccess = false;
 
                                                 //Db Zugriff zusammenfügen...
-                                                if (akRw.CombineDBAccess)
+                                                if (akRowInAwlCode < retVal.AWLCode.Count - 1 && akRw.CombineDBAccess)
                                                 {
                                                     S7FunctionBlockRow nRw = (S7FunctionBlockRow) retVal.AWLCode[akRowInAwlCode + 1];
                                                     nRw.Parameter = akRw.Parameter + "." + nRw.Parameter;

--- a/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/CallConverter.cs
+++ b/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/CallConverter.cs
@@ -51,7 +51,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
                 for (int n = 0; n < myFct.AWLCode.Count; n++)
                 {
                     S7FunctionBlockRow row = (S7FunctionBlockRow)myFct.AWLCode[n];
-                    if (row.Command == Mnemonic.opBLD[(int)myOpt.Mnemonic] && (row.Parameter == "1" || row.Parameter == "7" || row.Parameter == "3" || row.Parameter == "16" || row.Parameter == "14") && inBld == 0)
+                    if (row.Command == Mnemonic.opBLD[(int)myOpt.Mnemonic] && (row.Parameter == "1" || row.Parameter == "7" || row.Parameter == "3" || row.Parameter == "16" || row.Parameter == "14" || row.Parameter == "9") && inBld == 0)
                     {
                         retVal.AddRange(tempList);
                         tempList.Clear();
@@ -418,7 +418,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
                         }
                         #endregion
                     }
-                    else if (inBld == 3 || inBld == 16 || inBld == 14)
+                    else if (inBld == 3 || inBld == 16 || inBld == 14 || inBld == 9)
                     {                        
                         #region FB Aufruf
                         tempList.Add(row);
@@ -542,7 +542,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
                             callRow = row;
                             afterCall = true;
                         }
-                        else if (row.Command == Mnemonic.opBLD[(int)myOpt.Mnemonic] && (row.Parameter == "4" || row.Parameter == "17" || row.Parameter == "15"))
+                        else if (row.Command == Mnemonic.opBLD[(int)myOpt.Mnemonic] && (row.Parameter == "4" || row.Parameter == "17" || row.Parameter == "15" || row.Parameter == "10"))
                         {
                             //Block Interface auslesen (von FC oder vom Programm)
                             S7DataRow para = myblkFld.GetInterface(callRow.Parameter);


### PR DESCRIPTION
example of SFB AWL that was not getting converted to Call:
```
BLD 9;
= L45.0;
TDB ;
AUF DI1;
TAR2 LD41;
LAR2 P#DBX 0.0;
UC SFB0;
LAR2 LD41;
TDB ;
BLD 10;
```

after:
```
CALL  SFB0, DB1 (
      CU := ,
      R  := ,
      PV := ,
      Q  := ,
      CV := );
```

![image](https://github.com/dotnetprojects/DotNetSiemensPLCToolBoxLibrary/assets/43485413/554e3f68-2cc3-4e3e-a7cf-8d665de03835)
