### PR TITLE
handles empty address for Step7Vat block

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7VATBlock.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7VATBlock.cs
@@ -102,23 +102,26 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
                         addr += hexCode[akAddr] - 0x30;
                         akAddr++;
                     }
-                    tmp.ByteAddress = Convert.ToInt32(addr);
-                    akAddr++;
-                    if (bit == true)
+                    if (addr != "")
                     {
-                        tmp.BitAddress = Convert.ToInt32(hexCode[akAddr] - 0x30);
-                    }
-                    akAddr++;
-                    akAddr++;
-                    if (db != "")
-                    {
-                        addr = "";
-                        while (hexCode[akAddr] != 0x20)
+                        tmp.ByteAddress = Convert.ToInt32(addr);
+                        akAddr++;
+                        if (bit == true)
                         {
-                            addr += hexCode[akAddr] - 0x30;
-                            akAddr++;
+                            tmp.BitAddress = Convert.ToInt32(hexCode[akAddr] - 0x30);
                         }
-                        tmp.DataBlockNumber = Convert.ToInt32(addr);
+                        akAddr++;
+                        akAddr++;
+                        if (db != "")
+                        {
+                            addr = "";
+                            while (hexCode[akAddr] != 0x20)
+                            {
+                                addr += hexCode[akAddr] - 0x30;
+                                akAddr++;
+                            }
+                            tmp.DataBlockNumber = Convert.ToInt32(addr);
+                        }
                     }
                     akAddr++;
                     akAddr++;


### PR DESCRIPTION
We (@ryan2445) and I were generating an error: `The input string '' was not in a correct format.` from `Convert.ToInt32(addr)`. We found that `addr` was set to `""` at the time and causing the error.

For context, if it has any relation, the `akAddr` at the time was 40