### PR TITLE
Fix getting block dependencies for function blocks using DBs

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7FunctionBlockRow.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7FunctionBlockRow.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Text;
 using DotNetSiemensPLCToolBoxLibrary.Communication.LibNoDave;
 using DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders;
@@ -621,27 +622,23 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
                 }
                 else if (Command == Mnemonic.opCALL[(int)MnemonicLanguage])
                 {
+                    var deps = new List<String>();
+
                     if (!String.IsNullOrEmpty(DiName))
                     {
-                        /*Block blk1, blk2;
-                        var fld = (this.Parent).ParentFolder as BlocksOfflineFolder;
-                        if (fld != null && !Parameter.StartsWith("#"))
-                        {
-                            var blk1 = fld.GetBlock(Parameter);                           
-                        }
+                        var db = DiName.Replace("DI", "DB");
 
-                        return new List<Block>() { blk1, blk2 };*/
+                        deps.Add(db);
                     }
-                    else
+
+                    var fld = (this.Parent).ParentFolder as BlocksOfflineFolder;
+
+                    if (fld != null && !Parameter.StartsWith("#"))
                     {
-                        var fld = (this.Parent).ParentFolder as BlocksOfflineFolder;
-                        if (fld != null && !Parameter.StartsWith("#"))
-                        {
-                            //var blk = fld.GetBlock(Parameter);
-
-                            return new List<String>() { Parameter };
-                        }
+                        deps.Add(Parameter);
                     }
+
+                    return deps;
                 }
                 else if (Parameter.StartsWith("DB") && Parameter[2] != '[' && Parameter[2] != 'D' && Parameter[2] != 'W' && Parameter[2] != 'B' && Parameter[2] != 'X' && this.Parent != null)
                 {
@@ -649,12 +646,12 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
                     var fld = (this.Parent).ParentFolder as BlocksOfflineFolder;
                     if (fld != null)
                     {
-                        if (paras.Length > 1)
+                        if (paras.Length > 0)
                         {
-                            var byteAdr = int.Parse(paras[1].Replace("DBX", "").Replace("DBB", "").Replace("DBW", "").Replace("DBD", ""));
+                            // var byteAdr = int.Parse(paras[1].Replace("DBX", "").Replace("DBB", "").Replace("DBW", "").Replace("DBD", ""));
 
-                            var bitAdr = 0;
-                            if (paras.Length > 2) bitAdr = int.Parse(paras[2]);
+                            // var bitAdr = 0;
+                            // if (paras.Length > 2) bitAdr = int.Parse(paras[2]);
 
                             //var dbBlk = fld.GetBlock(paras[0]) as S7DataBlock;
 

--- a/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
@@ -137,7 +137,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
         /// <summary>
         /// Help class, used to hold unparsed raw data read from the S7 Project files from disk
         /// </summary>
-        private class tmpBlock
+        public class TmpBlock
         {
             public byte[] mc7code;
             public byte[] uda;
@@ -161,7 +161,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
             public PLCLanguage BlockLanguage;
         }
 
-        private Dictionary<string, tmpBlock> tmpBlocks; //internal cached list of blocks already read from the S7 Project
+        private Dictionary<string, TmpBlock> tmpBlocks; //internal cached list of blocks already read from the S7 Project
 
         public ProjectBlockInfo GetProjectBlockInfoFromBlockName(string BlockName)
         {
@@ -176,7 +176,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
 
         public void ChangeKnowHowProtection(S7ProjectBlockInfo blkInfo, bool KnowHowProtection)
         {
-            tmpBlock myTmpBlk = new tmpBlock();
+            TmpBlock myTmpBlk = new TmpBlock();
 
             if (subblkDBF != null)
             {
@@ -207,7 +207,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
 
         public void UndeleteBlock(S7ProjectBlockInfo blkInfo, int newBlockNumber)
         {
-            tmpBlock myTmpBlk = new tmpBlock();
+            TmpBlock myTmpBlk = new TmpBlock();
 
             if (((Step7ProjectV5)Project)._ziphelper.FileExists(Folder + "BAUSTEIN.DBF"))
             {
@@ -247,11 +247,11 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
         /// </summary>
         /// <param name="blkInfo">The Block info object that identifies the block to read from Disk</param>
         /// <returns></returns>
-        private tmpBlock GetBlockBytes(ProjectBlockInfo blkInfo)
+        public TmpBlock GetBlockBytes(ProjectBlockInfo blkInfo)
         {
             if (subblkDBF != null) //ZipHelper.FileExists(((Step7ProjectV5)Project)._zipfile, Folder + "SUBBLK.DBF"))
             {
-                tmpBlock myTmpBlk = new tmpBlock();
+                TmpBlock myTmpBlk = new TmpBlock();
 
                 var bstTbl = bausteinDBF;
                 DataRow[] bstRows = bstTbl.Select("ID = " + blkInfo.id);
@@ -415,7 +415,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
         /// </summary>
         /// <param name="blkName">The blockname to be read from disk. eg. DB2, FB38....</param>
         /// <returns></returns>
-        private tmpBlock GetBlockBytes(string blkName)
+        private TmpBlock GetBlockBytes(string blkName)
         {
             var blkInfo = GetProjectBlockInfoFromBlockName(blkName);
             if (blkInfo == null)
@@ -428,7 +428,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
             var blkInfo = GetProjectBlockInfoFromBlockName(blkName);
             if (blkInfo == null)
                 return null;
-            tmpBlock myTmpBlk = GetBlockBytes(blkInfo);
+            TmpBlock myTmpBlk = GetBlockBytes(blkInfo);
             List<string> tmpPar = new List<string>();
             return Parameter.GetInterfaceOrDBFromStep7ProjectString(myTmpBlk.blkinterface, ref tmpPar, blkInfo.BlockType, false, this, null);
         }
@@ -483,7 +483,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
 
 
             ProjectPlcBlockInfo plcblkifo = (ProjectPlcBlockInfo)blkInfo;
-            tmpBlock myTmpBlk = GetBlockBytes(blkInfo);
+            TmpBlock myTmpBlk = GetBlockBytes(blkInfo);
 
             List<Step7Attribute> step7Attributes = null;
 
@@ -539,7 +539,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                     if (retVal.IsInstanceDB && myConvOpt.UseFBDeclarationForInstanceDB)
                     {
                         //load the FB data from the Project
-                        tmpBlock InstFB = GetBlockBytes((myTmpBlk.IsSFB ? "SFB" : "FB") + myTmpBlk.FBNumber);
+                        TmpBlock InstFB = GetBlockBytes((myTmpBlk.IsSFB ? "SFB" : "FB") + myTmpBlk.FBNumber);
 
                         //Resolve both interfaces
                         List<string> tmpPar = new List<string>();

--- a/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Helper.cs
+++ b/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Helper.cs
@@ -444,7 +444,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
         {
             time = time.ToLower().Replace("s5t#", "").Replace("t#", "").Replace("\t", "");
             //need another text for ms (because it could be minute)
-            time = time.Replace("ms", "a");
+            time = time.Replace("ms", "a").Trim();
 
             int d = 0, h = 0, m = 0, s = 0, ms = 0;
             int val = 0;

--- a/LibNoDaveConnectionLibrary/Projectfiles/Step7ProjectV5.cs
+++ b/LibNoDaveConnectionLibrary/Projectfiles/Step7ProjectV5.cs
@@ -156,8 +156,11 @@ namespace DotNetSiemensPLCToolBoxLibrary.Projectfiles
             fsProject.Read(projectFile, 0, projectFile.Length);//Convert.ToInt32(fsProject.Length));
             fsProject.Close();
 
-            ProjectName = System.Text.Encoding.UTF7.GetString(projectFile, 5, projectFile[4]);
-            ProjectDescription = System.Text.Encoding.UTF7.GetString(projectFile, 5 + projectFile[4] + 2, projectFile[projectFile[4] + 6]);
+            ProjectName = Encoding.UTF7.GetString(projectFile, 5, projectFile[4]);
+
+            int descStart = 5 + projectFile[4] + 2;
+            int descCount = Math.Min(projectFile[projectFile[4] + 6], projectFile.Length - 1 - descStart);
+            ProjectDescription = Encoding.UTF7.GetString(projectFile, descStart, descCount);
             //Fertig
 
             _offlineblockdb = ProjectFolder + "ombstx" + _DirSeperator + "offline" + _DirSeperator + "BSTCNTOF.DBF";


### PR DESCRIPTION
- Makes sure the block name and DB# get added to the dependencies list for function blocks that use a DB
- I wanted to use GetBlockBytes to get some of the block data without parsing everything upfront (some large blocks take a little while) so I made GetBlockBytes a public function. Hopefully that's ok :)
- Fixes an index out of range error while getting step7 v5 project description