### PR TITLE
Combine DB access when there are no comments

### DIFF
--- a/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Parameter.cs
+++ b/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Parameter.cs
@@ -1052,7 +1052,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
         /// <returns>the parsed value acording to the given datatyep and adress. If the datatype is invalid (such as struct) it returns Null</returns>
         internal static object GetVarCurrentValue(S7DataRowType dataType, byte[] data, ByteBitAddress valpos)
         {
-            if (data == null || valpos.ByteAddress > data.Length) return null;
+            if (data == null || valpos.ByteAddress >= data.Length) return null;
 
             //Parse Value from data depending on its interface type
             object Result;


### PR DESCRIPTION
The `CombineDBAccess` code was nested within the comments code. If there were no comments, DB accesses were not getting combined. I moved that code outside of the `if (myConvOpt.UseComments)` check.