### PR TITLE
Get CP400's, fix duplicate H CPUs

### DIFF
--- a/LibNoDaveConnectionLibrary/Projectfiles/Step7ProjectV5.cs
+++ b/LibNoDaveConnectionLibrary/Projectfiles/Step7ProjectV5.cs
@@ -353,7 +353,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.Projectfiles
                     }
                 }
             }
-            
+
             /*
             //Get The HW Folder for the Station...
             if (ZipHelper.FileExists(_zipfile,ProjectFolder + "hOmSave7" + _DirSeperator + "s7hstatx" + _DirSeperator + "HRELATI1.DBF"))
@@ -396,9 +396,23 @@ namespace DotNetSiemensPLCToolBoxLibrary.Projectfiles
 
 
             //Get The CPs...
-            if (_ziphelper.FileExists(ProjectFolder + "hOmSave7" + _DirSeperator + "s7wb53ax" + _DirSeperator + "HOBJECT1.DBF"))
+            string cp300Base = ProjectFolder + "hOmSave7" + _DirSeperator + "s7wb53ax" + _DirSeperator;
+            string cp400Base = ProjectFolder + "hOmSave7" + _DirSeperator + "s7w1105x" + _DirSeperator;
+
+            List<string> cpPaths = new List<string>();
+            string cp300 = cp300Base + "HOBJECT1.DBF";
+            if (_ziphelper.FileExists(cp300))
             {
-                var dbfTbl = DBF.ParseDBF.ReadDBF(ProjectFolder + "hOmSave7" + _DirSeperator + "s7wb53ax" + _DirSeperator + "HOBJECT1.DBF", _ziphelper, _DirSeperator);
+                cpPaths.Add(cp300);
+            }
+            string cp400 = cp400Base + "HOBJECT1.DBF";
+            if (_ziphelper.FileExists(cp400))
+            {
+                cpPaths.Add(cp400);
+            }
+            foreach (string cpPath in cpPaths)
+            {
+                var dbfTbl = DBF.ParseDBF.ReadDBF(cpPath, _ziphelper, _DirSeperator);
 
                 foreach (DataRow row in dbfTbl.Rows)
                 {
@@ -426,9 +440,20 @@ namespace DotNetSiemensPLCToolBoxLibrary.Projectfiles
             }
 
             //Get The CP Folders
-            if (_ziphelper.FileExists(ProjectFolder + "hOmSave7" + _DirSeperator + "s7wb53ax" + _DirSeperator + "HRELATI1.DBF"))
+            List<string> cpFolderPaths = new List<string>();
+            string cp300Folder = cp300Base + "HRELATI1.DBF";
+            if (_ziphelper.FileExists(cp300Folder))
             {
-                var dbfTbl = DBF.ParseDBF.ReadDBF(ProjectFolder + "hOmSave7" + _DirSeperator + "s7wb53ax" + _DirSeperator + "HRELATI1.DBF", _ziphelper, _DirSeperator);
+                cpFolderPaths.Add(cp300Folder);
+            }
+            string cp400Folder = cp400Base + "HRELATI1.DBF";
+            if (_ziphelper.FileExists(cp400Folder))
+            {
+                cpFolderPaths.Add(cp400Folder);
+            }
+            foreach (string cpFolderPath in cpFolderPaths)
+            {
+                var dbfTbl = DBF.ParseDBF.ReadDBF(cpFolderPath, _ziphelper, _DirSeperator);
                 foreach(DataRow row in dbfTbl.Rows)
                 {
                     if (!(bool)row["DELETED_FLAG"] || _showDeleted)
@@ -531,7 +556,9 @@ namespace DotNetSiemensPLCToolBoxLibrary.Projectfiles
                         {
                             if (!(bool)row["DELETED_FLAG"] || _showDeleted)
                             {
-                                if ((int)row["TUNITID"] == z.ID && ((int)row["TOBJTYP"] == 1314972 || (int)row["TOBJTYP"] == 1315656 /* BackupCPU bei H Sys */))
+                                if ((int)row["TUNITID"] == z.ID && 
+                                    ((int)row["TOBJTYP"] == 1314972 || (int)row["TOBJTYP"] == 1315656 /* BackupCPU bei H Sys */) &&
+                                    CPUFolders.FirstOrDefault(folder => folder.ID == (int)row["SOBJID"]) == null)
                                 //((int)row["TUNITTYP"] == 1314969 || (int)row["TUNITTYP"] == 1314969 || (int)row["TUNITTYP"] == 1314969))
                                 {
                                     var x = new CPUFolder() { Project = this };

--- a/LibNoDaveConnectionLibrary/Projectfiles/Step7ProjectV5.cs
+++ b/LibNoDaveConnectionLibrary/Projectfiles/Step7ProjectV5.cs
@@ -558,7 +558,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.Projectfiles
                             {
                                 if ((int)row["TUNITID"] == z.ID && 
                                     ((int)row["TOBJTYP"] == 1314972 || (int)row["TOBJTYP"] == 1315656 /* BackupCPU bei H Sys */) &&
-                                    CPUFolders.FirstOrDefault(folder => folder.ID == (int)row["SOBJID"]) == null)
+                                    CPUFolders.FirstOrDefault(folder => folder.ID == (int)row["SOBJID"]) == null) /* skip over duplicate CPU folders */
                                 //((int)row["TUNITTYP"] == 1314969 || (int)row["TUNITTYP"] == 1314969 || (int)row["TUNITTYP"] == 1314969))
                                 {
                                     var x = new CPUFolder() { Project = this };


### PR DESCRIPTION
I had a Simatic Manager project with one H-Station, two CPU 412-5 H PN/DP, and two CP 443-1 parts. The two CP 443-1 parts were not being returned as sub-items of the station. I found that they were stored in database files at `hOmSave7/s7w1105x`, so I added this path in addition to `hOmSave7/s7wb53ax` which was already being searched. I'm not sure why the CP 400's show up in this directory sometimes.

I also noticed there were duplicate folders being returned for CPU 412-5 H PN/DP (records in the .DBF file with the same ID too) so I added an additional check to not add the CPU folder if one already exists with the same ID. See below:

project:
![image](https://github.com/dotnetprojects/DotNetSiemensPLCToolBoxLibrary/assets/43485413/825fe4ef-ace7-42e9-8502-9a1ec6f9773e)

old output:
```
{ ID: 1, Name: "CPU 412-5 H PN/DP", ... },
{ ID: 1, Name: "CPU 412-5 H PN/DP", ... },
{ ID: 2, Name: "CPU 412-5 H PN/DP(1)", ... },
...
```

new output:
```
{ ID: 1, Name: "CPU 412-5 H PN/DP", ... },
{ ID: 2, Name: "CPU 412-5 H PN/DP(1)", ... },
{ ID: 1, Name: "CP 443-1", ... },
{ ID: 2, Name: "CP 443-1(1)", ... },
...
```