### PR TITLE
Step7v5: add option to use MC7 interface when there are timestamp conflicts

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/AWL/Step7V5/S7ConvertingOptions.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/AWL/Step7V5/S7ConvertingOptions.cs
@@ -17,7 +17,10 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.AWL.Step7V5
                 && this.ReplaceDIAccessesWithSymbolNames.Equals(other.ReplaceDIAccessesWithSymbolNames) 
                 && this.GenerateCallsfromUCs.Equals(other.GenerateCallsfromUCs) 
                 && this.UseInFCStoredFCsForCalls.Equals(other.UseInFCStoredFCsForCalls)
-                && this.UseFBDeclarationForInstanceDB.Equals(other.UseFBDeclarationForInstanceDB);
+                && this.UseFBDeclarationForInstanceDB.Equals(other.UseFBDeclarationForInstanceDB)
+                && this.UseDBActualValues.Equals(other.UseDBActualValues)
+                && this.ExpandArrays.Equals(other.ExpandArrays)
+                && this.CheckForInterfaceTimestampConflicts.Equals(other.CheckForInterfaceTimestampConflicts);
         }
 
         public override int GetHashCode()
@@ -33,6 +36,9 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.AWL.Step7V5
                 hashCode = (hashCode * 397) ^ this.GenerateCallsfromUCs.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.UseInFCStoredFCsForCalls.GetHashCode();
                 hashCode = (hashCode * 397) ^ this.UseFBDeclarationForInstanceDB.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.UseDBActualValues.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.ExpandArrays.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.CheckForInterfaceTimestampConflicts.GetHashCode();
                 return hashCode;
             }
         }
@@ -55,6 +61,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.AWL.Step7V5
             this.UseFBDeclarationForInstanceDB = true; //Default to Simatic Mamager Behavior
             this.UseDBActualValues = false;
             this.ExpandArrays = false;
+            this.CheckForInterfaceTimestampConflicts = false;
         }
 
         public bool UseComments { get; set; }
@@ -70,6 +77,8 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.AWL.Step7V5
 
         public bool GenerateCallsfromUCs { get; set;}
         public bool UseInFCStoredFCsForCalls { get; set; }
+
+        public bool CheckForInterfaceTimestampConflicts { get; set; }
 
         /// <summary>
         /// use the FB instance declartion symbolics for displaying Instance DB Variables

--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
@@ -93,6 +93,31 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
         public DateTime LastInterfaceChange { get; set; }
 
         /// <summary>
+        /// Timestamp of the last interface change associated with the plaintext database record
+        /// If a block is uploaded to the project with a timestamp conflict, this field contains the previous modified date of the interface before the upload
+        /// </summary>
+        public DateTime LastInterfaceChangeHistory { get; set; }
+
+        /// <summary>
+        /// Returns true if the plaintext interface timestamp is different from the MC7 interface timestamp
+        /// The default value of DateTime is DateTime.MinValue, so also check to make sure that both values are set
+        /// </summary>
+        public bool HasInterfaceTimestampConflict
+        {
+            get
+            {
+                if (!LastInterfaceChangeHistory.Equals(DateTime.MinValue) &&
+                    !LastInterfaceChange.Equals(DateTime.MinValue) &&
+                    !LastInterfaceChangeHistory.Equals(LastInterfaceChange))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
         /// The total size of the Interface table 
         /// </summary>
         /// <remarks>this is an internal property, that is not shown in Simatic Manager</remarks>

--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataBlock.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataBlock.cs
@@ -53,7 +53,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
         {
             get
             {
-                bool checkIFaceConflict = usedS7ConvertingOptions.CheckForInterfaceTimestampConflicts;
+                bool checkIFaceConflict = usedS7ConvertingOptions != null && usedS7ConvertingOptions.CheckForInterfaceTimestampConflicts;
 
                 if ((!checkIFaceConflict && StructureFromString != null) || (checkIFaceConflict && !HasInterfaceTimestampConflict))
                 {

--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataBlock.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataBlock.cs
@@ -53,8 +53,13 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
         {
             get
             {
-                if (StructureFromString != null) 
+                bool checkIFaceConflict = usedS7ConvertingOptions.CheckForInterfaceTimestampConflicts;
+
+                if ((!checkIFaceConflict && StructureFromString != null) || (checkIFaceConflict && !HasInterfaceTimestampConflict))
+                {
                     return StructureFromString;
+                }
+
                 return StructureFromMC7;
             }
             set

--- a/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Parameter.cs
+++ b/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Parameter.cs
@@ -642,6 +642,14 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
             S7DataRow parameterTEMP = new S7DataRow("TEMP", S7DataRowType.STRUCT, myBlk);
             S7DataRow parameterRETVAL = new S7DataRow("RET_VAL", S7DataRowType.STRUCT, myBlk);
 
+            parameterIN.isRootBlock = true;
+            parameterOUT.isRootBlock = true;
+            parameterINOUT.isRootBlock = true;
+            parameterINOUT.isInOut = true;
+            parameterSTAT.isRootBlock = true;
+            parameterTEMP.isRootBlock = true;
+            parameterRETVAL.isRootBlock = true;
+
             //All blocks may have In, Out or In/Out parameters
             //Info: the order in which they are added to the Root is important
             parameterRoot.Add(parameterIN);


### PR DESCRIPTION
- Added `LastInterfaceChangeHistory` and `HasInterfaceTimestampConflict` fields to `S7Block` class. `LastInterfaceChangeHistory` stores the interface timestamp of the last save (not including upload) while `LastInterfaceChange` stores the timestamp of the last save or upload.
- If there is a timestamp conflict, the MC7 interface is used when setting the FunctionBlock Parameter field and also when returning the Structure field for DataBlocks.
- The MC7 interface code (`blkinterfaceInMc5`) is now set correctly for FC, OB, FB, SFB, SFC blocks
- Added function `GetInterfaceStructureFromMC7` to parse the MC7 interface code from the offline block .DBT files
- Added conversion option `CheckForInterfaceTimestampConflicts = false` so people would have to opt in to the above behavior
- Fixed bug where `isRootBlock` was always `false` on the MC7 interface objects which caused address values to be set incorrectly