### PR TITLE
Fix tests & remove parent reference during DeepCopy()

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataRow.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataRow.cs
@@ -68,7 +68,6 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
         public override TiaAndSTep7DataBlockRow DeepCopy()
         {
             S7DataRow newRow = new S7DataRow(this.Name, this.DataType, this.PlcBlock);
-            newRow.Parent = this.Parent;
             newRow.ArrayStart = this.ArrayStart;
             newRow.ArrayStop = this.ArrayStop;
             newRow.IsArray = this.IsArray;

--- a/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Parameter.cs
+++ b/LibNoDaveConnectionLibrary/PLCs/S7_xxx/MC7/Parameter.cs
@@ -642,14 +642,6 @@ namespace DotNetSiemensPLCToolBoxLibrary.PLCs.S7_xxx.MC7
             S7DataRow parameterTEMP = new S7DataRow("TEMP", S7DataRowType.STRUCT, myBlk);
             S7DataRow parameterRETVAL = new S7DataRow("RET_VAL", S7DataRowType.STRUCT, myBlk);
 
-            parameterIN.isRootBlock = true;
-            parameterOUT.isRootBlock = true;
-            parameterINOUT.isRootBlock = true;
-            parameterINOUT.isInOut = true;
-            parameterSTAT.isRootBlock = true;
-            parameterTEMP.isRootBlock = true;
-            parameterRETVAL.isRootBlock = true;
-
             //All blocks may have In, Out or In/Out parameters
             //Info: the order in which they are added to the Root is important
             parameterRoot.Add(parameterIN);


### PR DESCRIPTION
Removes changes in `Parameter.cs` that I added in my last PR which caused the tests to fail

But we can't set `newRow.Parent = this.Parent` when cloning because it creates references to the old object. I think this change is okay