### PR TITLE
step7v5: handle interface timestamp conflicts in GetInterface(string blkName, S7ConvertingOptions myConvOpt)

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
@@ -99,25 +99,6 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
         public DateTime LastInterfaceChangeHistory { get; set; }
 
         /// <summary>
-        /// Returns true if the plaintext interface timestamp is different from the MC7 interface timestamp
-        /// The default value of DateTime is DateTime.MinValue, so also check to make sure that both values are set
-        /// </summary>
-        public bool HasInterfaceTimestampConflict
-        {
-            get
-            {
-                if (!LastInterfaceChangeHistory.Equals(DateTime.MinValue) &&
-                    !LastInterfaceChange.Equals(DateTime.MinValue) &&
-                    !LastInterfaceChangeHistory.Equals(LastInterfaceChange))
-                {
-                    return true;
-                }
-
-                return false;
-            }
-        }
-
-        /// <summary>
         /// The total size of the Interface table 
         /// </summary>
         /// <remarks>this is an internal property, that is not shown in Simatic Manager</remarks>
@@ -235,6 +216,22 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
             //WriteProtected
             //ReadOnly
 
+        }
+
+        /// <summary>
+        /// Returns true if dt1 and dt2 are not equal
+        /// Also checks that both values are not the default value (DateTime.MinValue)
+        /// </summary>
+        public static bool HasTimestampConflict(DateTime dt1, DateTime dt2)
+        {
+            if (!dt1.Equals(DateTime.MinValue) &&
+                !dt2.Equals(DateTime.MinValue) &&
+                !dt1.Equals(dt2))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataBlock.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataBlock.cs
@@ -55,7 +55,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
             {
                 bool checkIFaceConflict = usedS7ConvertingOptions != null && usedS7ConvertingOptions.CheckForInterfaceTimestampConflicts;
 
-                if ((!checkIFaceConflict && StructureFromString != null) || (checkIFaceConflict && !HasInterfaceTimestampConflict))
+                if ((!checkIFaceConflict && StructureFromString != null) || (checkIFaceConflict && !HasTimestampConflict(LastInterfaceChange, LastInterfaceChangeHistory)))
                 {
                     return StructureFromString;
                 }

--- a/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
@@ -449,7 +449,14 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                 return null;
             TmpBlock myTmpBlk = GetBlockBytes(blkInfo);
             List<string> tmpPar = new List<string>();
-            return Parameter.GetInterfaceOrDBFromStep7ProjectString(myTmpBlk.blkinterface, ref tmpPar, blkInfo.BlockType, false, this, null, myConvOpt);
+            if (myConvOpt.CheckForInterfaceTimestampConflicts && S7Block.HasTimestampConflict(myTmpBlk.LastInterfaceChange, myTmpBlk.LastInterfaceChangeHistory))
+            {
+                return GetInterfaceStructureFromMC7(blkInfo, myTmpBlk, null, ref tmpPar);
+            }
+            else
+            {
+                return Parameter.GetInterfaceOrDBFromStep7ProjectString(myTmpBlk.blkinterface, ref tmpPar, blkInfo.BlockType, false, this, null, myConvOpt);
+            }
         }
 
         /// <summary>
@@ -625,7 +632,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                     retVal.Author = myTmpBlk.username;
                     retVal.Version = myTmpBlk.version;
 
-                    if (myConvOpt.CheckForInterfaceTimestampConflicts && retVal.HasInterfaceTimestampConflict)
+                    if (myConvOpt.CheckForInterfaceTimestampConflicts && S7Block.HasTimestampConflict(retVal.LastInterfaceChange, retVal.LastInterfaceChangeHistory))
                     {
                         retVal.Parameter = GetInterfaceStructureFromMC7(blkInfo, myTmpBlk, retVal, ref ParaList);
                     }


### PR DESCRIPTION
- changed timestamp conflict helper to a function so that `TmpBlock` class can use it
- added check in `GetInterface(string blkName, S7ConvertingOptions myConvOpt)` to handle MC7 vs. String interface parsing