### PR TITLE
step7v5: Handle case where block doesn't exist offline during upload in `HasTimestampConflict`

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
@@ -224,9 +224,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
         /// </summary>
         public static bool HasTimestampConflict(DateTime dt1, DateTime dt2)
         {
-            if (!dt1.Equals(DateTime.MinValue) &&
-                !dt2.Equals(DateTime.MinValue) &&
-                !dt1.Equals(dt2))
+            if (!dt1.Equals(dt2))
             {
                 return true;
             }


### PR DESCRIPTION
If block is uploaded and doesn't exist offline, there is no timestamp set. This function wasn't handling that case