### PR TITLE
Fix S7 offline blocks with comments can't generate AWL Code

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Projectfolders/Step7V5/BlocksOfflineFolder.cs
@@ -668,6 +668,24 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
 
                         FBStaticAccessConverter.ReplaceStaticAccess(retVal, prgFld, myConvOpt);                        
 
+                        for (int i = 0; i < retVal.AWLCode.Count - 1; i++)
+                        {
+                            S7FunctionBlockRow akRw = (S7FunctionBlockRow)retVal.AWLCode[i];
+
+                            if (akRw.CombineDBAccess)
+                            {
+                                S7FunctionBlockRow nRw = (S7FunctionBlockRow)retVal.AWLCode[i + 1];
+                                if (!nRw.Parameter.Contains("["))
+                                {
+                                    nRw.Parameter = akRw.Parameter + "." + nRw.Parameter;
+                                    nRw.MC7 = Helper.CombineByteArray(akRw.MC7, nRw.MC7);
+                                    nRw.Label = akRw.Label ?? nRw.Label;
+                                    retVal.AWLCode.RemoveAt(i + 1);
+                                    retVal.AWLCode[i] = nRw;
+                                }
+                            }
+                        }
+                        
                         #region UseComments from Block
                         if (myConvOpt.UseComments)
                         {
@@ -800,24 +818,6 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Projectfolders.Step7V5
                             retVal.AWLCode = newAwlCode;
                         }
                         #endregion
-
-                        for (int i = 0; i < retVal.AWLCode.Count - 1; i++)
-                        {
-                            S7FunctionBlockRow akRw = (S7FunctionBlockRow)retVal.AWLCode[i];
-
-                            if (akRw.CombineDBAccess)
-                            {
-                                S7FunctionBlockRow nRw = (S7FunctionBlockRow)retVal.AWLCode[i + 1];
-                                if (!nRw.Parameter.Contains("["))
-                                {
-                                    nRw.Parameter = akRw.Parameter + "." + nRw.Parameter;
-                                    nRw.MC7 = Helper.CombineByteArray(akRw.MC7, nRw.MC7);
-                                    nRw.Label = akRw.Label ?? nRw.Label;
-                                    retVal.AWLCode.RemoveAt(i + 1);
-                                    retVal.AWLCode[i] = nRw;
-                                }
-                            }
-                        }
                     }
 
                     retVal.Networks = NetWork.GetNetworksList(retVal);


### PR DESCRIPTION
Creating the AWL Code for offline blocks with comment did not work because the number of lines to skip for the next comment was calculated with combined DBAccess. Moving the combine step before adding the comments fixes the problem.