### PR TITLE
fix null reference exception on blocks with empty MC7 data

### DIFF
--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7Block.cs
@@ -224,6 +224,15 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
         /// </summary>
         public static bool HasTimestampConflict(DateTime dt1, DateTime dt2)
         {
+            // A MinValue timestamp means the corresponding record (offline plaintext or
+            // online MC7) was never present, so there is nothing to compare and no
+            // conflict to flag. Without this guard, a block that only has one of the
+            // two interface records reports a spurious conflict against MinValue.
+            if (dt1 == DateTime.MinValue || dt2 == DateTime.MinValue)
+            {
+                return false;
+            }
+
             if (!dt1.Equals(dt2))
             {
                 return true;

--- a/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataBlock.cs
+++ b/LibNoDaveConnectionLibrary/DataTypes/Blocks/Step7V5/S7DataBlock.cs
@@ -57,10 +57,13 @@ namespace DotNetSiemensPLCToolBoxLibrary.DataTypes.Blocks.Step7V5
 
                 if ((!checkIFaceConflict && StructureFromString != null) || (checkIFaceConflict && !HasTimestampConflict(LastInterfaceChange, LastInterfaceChangeHistory)))
                 {
-                    return StructureFromString;
+                    return StructureFromString ?? StructureFromMC7;
                 }
 
-                return StructureFromMC7;
+                // Fall back to the other source if the preferred one is missing — for
+                // example a DB whose SUBBLKTYP 10 record has an empty SSBPART (no MC7
+                // interface) yet the timestamps disagree.
+                return StructureFromMC7 ?? StructureFromString;
             }
             set
             {


### PR DESCRIPTION
- early return in HasTimestampConflict if either date/time is the default value (nothing to compare)
- fall back to plaintext data when MC7 bytes are null (and vice versa)