### PR TITLE
Fix: resolve project file paths case-insensitively (Linux block code lost)

### DIFF
--- a/LibNoDaveConnectionLibrary/General/ZipHelper.cs
+++ b/LibNoDaveConnectionLibrary/General/ZipHelper.cs
@@ -133,7 +133,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.General
             if (_zipFile == null)
             {
 #endif
-                return new FileStream(file, FileMode.Open, FileAccess.Read, System.IO.FileShare.ReadWrite);
+                return new FileStream(ResolveCaseInsensitivePath(file), FileMode.Open, FileAccess.Read, System.IO.FileShare.ReadWrite);
 #if SHARPZIPLIB
             }
             else
@@ -161,7 +161,7 @@ namespace DotNetSiemensPLCToolBoxLibrary.General
             if (_zipFile == null)
             {
 #endif
-                return new FileStream(file, FileMode.Open, FileAccess.Write, System.IO.FileShare.ReadWrite);
+                return new FileStream(ResolveCaseInsensitivePath(file), FileMode.Open, FileAccess.Write, System.IO.FileShare.ReadWrite);
 #if SHARPZIPLIB
             }
             else
@@ -249,13 +249,51 @@ namespace DotNetSiemensPLCToolBoxLibrary.General
             }
 #endif
         }
+        // STEP7 legt Dateien gemischt groß/klein ab (z.B. SUBBLK.DBT), die Library baut Pfade aber
+        // mit fester Schreibweise (z.B. ".dbt" klein in ParseDBF.openMemoFile). Auf case-sensitiven
+        // Dateisystemen (Linux) wird die Datei dann nicht gefunden -> Block-Code bleibt leer.
+        // Diese Methode löst einen Pfad case-insensitiv gegen das echte Dateisystem auf.
+        // Auf Windows (case-insensitiv) ist das ein No-Op über den File.Exists-Fastpath.
+        private static string ResolveCaseInsensitivePath(string file)
+        {
+            if (string.IsNullOrEmpty(file) || File.Exists(file) || Directory.Exists(file))
+                return file;
+            try
+            {
+                bool rooted = Path.IsPathRooted(file);
+                var parts = file.Split('/', '\\');
+                string cur = rooted ? "/" : ".";
+                for (int i = (rooted ? 1 : 0); i < parts.Length; i++)
+                {
+                    var part = parts[i];
+                    if (part.Length == 0) continue;
+                    string next = Path.Combine(cur, part);
+                    if (File.Exists(next) || Directory.Exists(next)) { cur = next; continue; }
+                    string match = null;
+                    try
+                    {
+                        foreach (var entry in Directory.GetFileSystemEntries(cur))
+                        {
+                            if (string.Equals(Path.GetFileName(entry), part, StringComparison.OrdinalIgnoreCase))
+                            { match = entry; break; }
+                        }
+                    }
+                    catch { }
+                    if (match == null) return file;
+                    cur = match;
+                }
+                return cur;
+            }
+            catch { return file; }
+        }
+
         public bool FileExists(string file)
         {
 #if SHARPZIPLIB
             if (_zipFile == null)
             {
 #endif
-                return System.IO.File.Exists(file);
+                return File.Exists(ResolveCaseInsensitivePath(file));
 #if SHARPZIPLIB
             }
             else


### PR DESCRIPTION
## Problem

On case-sensitive file systems (Linux), offline STEP7 V5 block bodies come back **empty** — `CodeSize == 0`, no AWL code, no DB structure — even though the project loads and the block list is complete.

Root cause: STEP7 V5 stores block code/values in DBF **memo files** (`.DBT`), and these are often written in upper case on disk (e.g. `SUBBLK.DBT`). `ParseDBF.openMemoFile` builds the memo path with a hard-coded lower-case extension:

```csharp
string dbtFile = Path.GetDirectoryName(dbfFile) + DirSeperator
               + Path.GetFileNameWithoutExtension(dbfFile) + ".dbt";
if (_ziphelper.FileExists(dbtFile)) { ... }
```

On Linux `FileExists("SUBBLK.dbt")` is `false` (the file is `SUBBLK.DBT`), so the memo reader is never opened and `ReadMemoBlock` returns `new byte[0]` for every memo field. As a side effect, an empty `ssbpart` whose claimed length (`ssbpartlen`) is > 2 also throws `IndexOutOfRangeException` in the instance-DB detection (`ssbpart[0]`), which aborts block enumeration entirely. On Windows none of this surfaces because the file system is case-insensitive.

## Fix

Resolve paths case-insensitively against the real file system in `ZipHelper` (`GetReadStream` / `GetWriteStream` / `FileExists`) via a new `ResolveCaseInsensitivePath` helper. It walks the path component by component and matches each segment case-insensitively. On Windows it is a no-op via the `File.Exists` fast-path. This fixes the general class of mixed-case file references, not just `.DBT`.

## Verification

Tested against a real S7-400/840D project on Linux (.NET 10, netstandard2.1 build):

- before: block list complete but every `GetBlock` returns `CodeSize 0` / empty structure; instance DBs throw `IndexOutOfRangeException`
- after: all 697 blocks load with no errors; FB AWL code and full DB structures (values + comments) are read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)